### PR TITLE
on_friendship_accepted hook: allow differentiating requested and requestor

### DIFF
--- a/lib/has_friendship/friendship.rb
+++ b/lib/has_friendship/friendship.rb
@@ -5,8 +5,14 @@ module HasFriendship
       friend.on_friendship_created(self)
     end
 
+    attr_reader :status_was
+
     enum status: { pending: 0, requested: 1, accepted: 2, blocked: 3 } do
       event :accept do
+        before do
+          @status_was = self.status
+        end
+
         transition [:pending, :requested] => :accepted
 
         after do


### PR DESCRIPTION
I'm adding a notification feed to a project using has_friendship, and I needed to differentiate between "THIS user accepted the friendship request" and "the OTHER user accepted YOUR friendship request" in the `on_friendship_accepted` hook. Since by the time the hook is run the passed Friendship's status is set to 'accepted' for both the initiator and the requestor, this PR adds a `status_was` method to be used in the hook like so:
```ruby
def on_friendship_accepted(friendship)
  if 'requested' == friendship.status_was
    # do stuff...
  else
    # do other stuff...
  end
end
```